### PR TITLE
fix rsync to not skip files

### DIFF
--- a/component-tools/build.sh
+++ b/component-tools/build.sh
@@ -22,7 +22,7 @@ npm install codemirror@$TAG
 
 
 cd "$work"
-rsync -ar --delete --exclude .git --exclude component-tools "$td/node_modules/codemirror/" "$work/"
+rsync -car --delete --exclude .git --exclude component-tools "$td/node_modules/codemirror/" "$work/"
 cp component-tools/bower.json "$work/"
 rm -rf "$td"
 


### PR DESCRIPTION
Found the issue that caused incorrect packages - the rsync command was silently excluding files if their mod time had not changed. Guessing there is some strangeness in how the npm package is built, shrug.